### PR TITLE
[feat]: add테스트코드 테스트케이스 추가,  add 페이지 유효성검사/입력 훅 추가

### DIFF
--- a/src/api/todos.ts
+++ b/src/api/todos.ts
@@ -19,6 +19,7 @@ const axiosClient = async (url: string, options: AxiosRequestConfig) => {
 };
 
 export const _addTodo = async (args: AddRequest) => {
+  console.log(123)
   try {
     //상태를 추가해 줌
     args = { ...args, state: false };

--- a/src/components/addTodo/Page.tsx
+++ b/src/components/addTodo/Page.tsx
@@ -2,81 +2,83 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import { _addTodo } from "../../api/todos";
 import { useNavigate } from "react-router-dom";
+import NormalModal from "../common/modal/NormalModal";
+import useTodoValidation from "../../hook/useTodoValidation";
 
 const Page = () => {
-  const navigate = useNavigate();
+  // input 관련 유효성검사가 포함된 훅
+  const { handleInputChange, InputData, errors } = useTodoValidation();
 
-  const [InputData, setInputData] = useState({
-    title: "",
-    detail: "",
-    startDate: "",
-    endDate: "",
-    state:false
-  });
+  const [modalState, setModalState] = useState("false");
+  const [modalContent, setModalContent] = useState("");
 
   const AddTodoHandler = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
+    //입력값중 하나라도 빈값이 있다면
+    for (const key in errors) {
+      if (errors[key as keyof typeof errors] !== "") {
+        setModalContent(Object.values(errors).join("\n"));
+        setModalState("true");
+        return;
+      }
+    }
+
     const addResult = await _addTodo(InputData);
 
     if (!addResult) {
-      alert("다시 시도해주세요");
+      setModalContent("다시 시도해주세요");
     } else {
-      alert("추가 완료");
-      navigate(-1);
+      setModalContent("할 일이 추가되었습니다.");
     }
-  };
 
-  const handleInputChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    const { name, value } = e.target;
-    setInputData({
-      ...InputData,
-      [name]: value,
-    });
+    setModalState("true");
   };
 
   return (
     <MainContent>
-    <form className="addForm" onSubmit={AddTodoHandler}>
-      <input
-        className="title"
-        type="text"
-        placeholder="title"
-        name="title"
-        value={InputData.title}
-        onChange={handleInputChange}
+      <NormalModal
+        content={modalContent}
+        modalState={modalState}
+        setModalState={setModalState}
       />
-      <textarea
-        placeholder="detail"
-        name="detail"
-        value={InputData.detail}
-        onChange={handleInputChange}
-      />
-      <label>
-        시작 날짜 :
+      <form className="addForm" onSubmit={AddTodoHandler}>
         <input
-          type="date"
-          name="startDate"
-          value={InputData.startDate}
+          className="title"
+          type="text"
+          placeholder="title"
+          name="title"
+          value={InputData.title}
           onChange={handleInputChange}
         />
-      </label>
-
-      <label>
-        끝 날짜 :
-        <input
-          type="date"
-          name="endDate"
-          value={InputData.endDate}
+        <textarea
+          placeholder="detail"
+          name="detail"
+          value={InputData.detail}
           onChange={handleInputChange}
         />
-      </label>
-      <button>추가</button>
-    </form>
-  </MainContent>
+        <label>
+          시작 날짜 :
+          <input
+            type="date"
+            name="startDate"
+            value={InputData.startDate}
+            onChange={handleInputChange}
+          />
+        </label>
 
+        <label>
+          끝 날짜 :
+          <input
+            type="date"
+            name="endDate"
+            value={InputData.endDate}
+            onChange={handleInputChange}
+          />
+        </label>
+        <button>추가</button>
+      </form>
+    </MainContent>
   );
 };
 

--- a/src/components/common/modal/NormalModal.tsx
+++ b/src/components/common/modal/NormalModal.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface ModalProps {
+  content: string;
+  modalState:string;
+  setModalState:React.Dispatch<React.SetStateAction<string>>
+}
+
+const Modal: React.FC<ModalProps> = ({ content,modalState,setModalState }) => {
+
+  const closeModal = () => {
+    setModalState('false')
+  };
+
+  return (
+    <ModalWrapper isOpen={modalState}>
+      <ModalContent>
+        <pre>{content}</pre>
+        <CloseButton onClick={closeModal}>Close</CloseButton>
+      </ModalContent>
+    </ModalWrapper>
+  );
+};
+
+export default Modal;
+
+const ModalWrapper = styled.div<{isOpen:string}>`
+  display: ${props => props.isOpen ==='true' ? 'block' : 'none'};
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1;
+`;
+
+const ModalContent = styled.div`
+  background: #fff;
+  max-width: 80%;
+  margin: 0 auto;
+  margin-top: 20%;
+  padding: 20px;
+  text-align: center;
+`;
+
+const CloseButton = styled.button`
+  margin-top: 10px;
+`;

--- a/src/components/main/Page.tsx
+++ b/src/components/main/Page.tsx
@@ -9,7 +9,7 @@ const Page = () => {
 
   const GetTodo = async () => {
     const _data = await _getTodo("running");
-    setData(_data);
+    setData(_data.slice(0,6));
   };
 
   useEffect(()=>{
@@ -18,8 +18,7 @@ const Page = () => {
 
   return (
     <MainContent>
-      zzz
-      <img src={Img_Man}></img>
+      <img src={Img_Man} alt="메인캐릭터"></img>
       <FallBoxs data={data}/>
     </MainContent>
   );

--- a/src/hook/useTodoValidation.tsx
+++ b/src/hook/useTodoValidation.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+
+const useValidation = () => {
+  // Todo 입력상태
+  const [InputData, setInputData] = useState({
+    title: "",
+    detail: "",
+    startDate: "",
+    endDate: "",
+    state: false,
+  });
+
+  //Todo 유효성결과 메세지
+  const [errors, setErrors] = useState({
+    title: "제목을 입력하세요.",
+    detail: "내용을 입력하세요.",
+    startDate: "시작 날짜를 입력하세요.",
+    endDate: "끝 날짜를 입력하세요.",
+  });
+
+  //Todo 상태 변경함수
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setInputData({
+      ...InputData,
+      [name]: value,
+    });
+
+    validationHandler(value, name);
+  };
+
+  const validationHandler = (value: string, name: string) => {
+    //유효성검사 (입력안한 항목이 있는지)
+    if (value === "") {
+      setErrors((prevErrors) => ({
+        ...prevErrors,
+        [name]: `${name} 값이 빈값입니다`,
+      }));
+    } else {
+      setErrors((prevErrors) => ({
+        ...prevErrors,
+        [name]: ``,
+      }));
+    }
+  };
+
+  return {
+    handleInputChange,
+    InputData,
+    errors,
+  };
+};
+
+export default useValidation;

--- a/src/test/add.test.tsx
+++ b/src/test/add.test.tsx
@@ -1,17 +1,26 @@
 import React from "react";
+import '@testing-library/jest-dom/extend-expect';
 import { MemoryRouter } from "react-router-dom";
 import { render, fireEvent, screen } from "@testing-library/react";
 import Add from "../pages/Add";
-import * as todosApi from "../api/todos"; 
+import * as todosApi from "../api/todos";
 
 /*
-    예상 시나리오:
-    title 입력 -> detail 입력 -> 시작날짜 입력 -> 끝 날짜입력 -> 추가버튼 클릭
+  테스트 항목 :
+      빈 제목으로 할 일을 추가하면 에러 메시지를 표시.
+      빈 내용으로 할 일을 추가하면 에러 메시지를 표시.
+      빈 시작 날짜로 할 일을 추가하면 에러 메시지를 표시.
+      빈 끝 날짜로 할 일을 추가하면 에러 메시지를 표시.
+      정상적인 데이터로 할 일을 추가할 수 있는지 확인.
+
+      부가적: 
+      제목 내용 시작날짜 끝날짜가 화면에 보이는지
+      함수 호출에 올바른 인자가 전달되는지  
 */
 
 describe("AddPage 컴포넌트 테스트", () => {
-  it("Add Todo 시나리오", async () => {
-    // 대체 모의 함수를 만들어서 테스트중 호출 반환값 추적
+
+  it("빈 제목으로 할 일을 추가하면 에러 메시지를 표시", async () => {
     const mockAddTodo = jest.spyOn(todosApi, "_addTodo");
 
     render(
@@ -20,29 +29,159 @@ describe("AddPage 컴포넌트 테스트", () => {
       </MemoryRouter>
     );
 
-    // 화면에 각 요소들이 출력되는지
+    // 각 입력 요소를 찾고 값 입력
     const titleInput = screen.getByPlaceholderText("title");
     const detailTextarea = screen.getByPlaceholderText("detail");
     const startDateInput = screen.getByLabelText("시작 날짜 :");
     const endDateInput = screen.getByLabelText("끝 날짜 :");
 
-    // onchage가 잘일어나는지
-    fireEvent.change(titleInput, { target: { value: "테스트 제목" } });
-    fireEvent.change(detailTextarea, { target: { value: "테스트 상세 내용" } });
+    fireEvent.change(titleInput, { target: { value: "" } });
+    fireEvent.change(detailTextarea, { target: { value: "할 일 설명입니다." } });
     fireEvent.change(startDateInput, { target: { value: "2023-10-30" } });
     fireEvent.change(endDateInput, { target: { value: "2023-11-05" } });
 
-    //버튼 클릭
+    const addButton = screen.getByText("추가");
+    fireEvent.click(addButton);
+
+    // mockAddTodo는 호출되지 않아야 함
+    expect(mockAddTodo).not.toHaveBeenCalled();
+
+    // 빈 제목 에러 메시지 확인
+    const errorMessage = await screen.findByText("제목을 입력하세요.");
+    expect(errorMessage).toBeInTheDocument();
+  });
+
+  it("빈 내용으로 할 일을 추가하면 에러 메시지를 표시", async () => {
+    const mockAddTodo = jest.spyOn(todosApi, "_addTodo");
+
+    render(
+      <MemoryRouter>
+        <Add />
+      </MemoryRouter>
+    );
+
+    // 각 입력 요소를 찾고 값 입력
+    const titleInput = screen.getByPlaceholderText("title");
+    const detailTextarea = screen.getByPlaceholderText("detail");
+    const startDateInput = screen.getByLabelText("시작 날짜 :");
+    const endDateInput = screen.getByLabelText("끝 날짜 :");
+
+    fireEvent.change(titleInput, { target: { value: "새로운 할 일" } });
+    fireEvent.change(detailTextarea, { target: { value: "" } });
+    fireEvent.change(startDateInput, { target: { value: "2023-10-30" } });
+    fireEvent.change(endDateInput, { target: { value: "2023-11-05" } });
+
+    const addButton = screen.getByText("추가");
+    fireEvent.click(addButton);
+
+    // mockAddTodo는 호출되지 않아야 함
+    expect(mockAddTodo).not.toHaveBeenCalled();
+
+    // 빈 제목 에러 메시지 확인
+    const errorMessage = await screen.findByText("내용을 입력하세요.");
+    expect(errorMessage).toBeInTheDocument();
+  });
+
+  it("빈 시작날짜로 할 일을 추가하면 에러 메시지를 표시", async () => {
+    const mockAddTodo = jest.spyOn(todosApi, "_addTodo");
+
+    render(
+      <MemoryRouter>
+        <Add />
+      </MemoryRouter>
+    );
+
+    // 각 입력 요소를 찾고 값 입력
+    const titleInput = screen.getByPlaceholderText("title");
+    const detailTextarea = screen.getByPlaceholderText("detail");
+    const startDateInput = screen.getByLabelText("시작 날짜 :");
+    const endDateInput = screen.getByLabelText("끝 날짜 :");
+
+    fireEvent.change(titleInput, { target: { value: "새로운 할 일" } });
+    fireEvent.change(detailTextarea, { target: { value: "할 일 설명입니다." } });
+    fireEvent.change(startDateInput, { target: { value: "" } });
+    fireEvent.change(endDateInput, { target: { value: "2023-11-05" } });
+
+    const addButton = screen.getByText("추가");
+    fireEvent.click(addButton);
+
+    // mockAddTodo는 호출되지 않아야 함
+    expect(mockAddTodo).not.toHaveBeenCalled();
+
+    // 빈 제목 에러 메시지 확인
+    const errorMessage = await screen.findByText("시작 날짜를 입력하세요.");
+    expect(errorMessage).toBeInTheDocument();
+  });
+
+  it("빈 끝날짜로 할 일을 추가하면 에러 메시지를 표시", async () => {
+    const mockAddTodo = jest.spyOn(todosApi, "_addTodo");
+
+    render(
+      <MemoryRouter>
+        <Add />
+      </MemoryRouter>
+    );
+
+    // 각 입력 요소를 찾고 값 입력
+    const titleInput = screen.getByPlaceholderText("title");
+    const detailTextarea = screen.getByPlaceholderText("detail");
+    const startDateInput = screen.getByLabelText("시작 날짜 :");
+    const endDateInput = screen.getByLabelText("끝 날짜 :");
+
+    fireEvent.change(titleInput, { target: { value: "새로운 할 일" } });
+    fireEvent.change(detailTextarea, { target: { value: "할 일 설명입니다." } });
+    fireEvent.change(startDateInput, { target: { value: "2023-10-30" } });
+    fireEvent.change(endDateInput, { target: { value: "" } });
+
+    const addButton = screen.getByText("추가");
+    fireEvent.click(addButton);
+
+    // mockAddTodo는 호출되지 않아야 함
+    expect(mockAddTodo).not.toHaveBeenCalled();
+
+    // 빈 제목 에러 메시지 확인
+    const errorMessage = await screen.findByText("끝 날짜를 입력하세요.");
+    expect(errorMessage).toBeInTheDocument();
+  });
+
+
+  it("할 일을 추가할 수 있는지 확인", async () => {
+    // 대체 모의 함수를 만들어서 테스트 중 호출 반환값 추적
+    const mockAddTodo = jest.spyOn(todosApi, "_addTodo");
+
+    render(
+      <MemoryRouter>
+        <Add />
+      </MemoryRouter>
+    );
+
+    // 각 입력 요소를 찾고 값 입력
+    const titleInput = screen.getByPlaceholderText("title");
+    const detailTextarea = screen.getByPlaceholderText("detail");
+    const startDateInput = screen.getByLabelText("시작 날짜 :");
+    const endDateInput = screen.getByLabelText("끝 날짜 :");
+
+    fireEvent.change(titleInput, { target: { value: "새로운 할 일" } });
+    fireEvent.change(detailTextarea, { target: { value: "할 일 설명입니다." } });
+    fireEvent.change(startDateInput, { target: { value: "2023-10-30" } });
+    fireEvent.change(endDateInput, { target: { value: "2023-11-05" } });
+
+    // 추가 버튼 클릭
     const addButton = screen.getByText("추가");
     fireEvent.click(addButton);
 
     // mockAddTodo의 호출에 제대로 된 값이 들어갔는지 확인
     expect(mockAddTodo).toHaveBeenCalledWith({
-      title: "테스트 제목",
-      detail: "테스트 상세 내용",
+      title: "새로운 할 일",
+      detail: "할 일 설명입니다.",
       startDate: "2023-10-30",
       endDate: "2023-11-05",
-      state: false, 
+      state: false,
     });
+
+    // 추가 후 성공 메시지 확인 
+    const successMessage = await screen.findByText("할 일이 추가되었습니다.");
+    expect(successMessage).toBeInTheDocument();
   });
 });
+

--- a/src/test/header.test.tsx
+++ b/src/test/header.test.tsx
@@ -12,11 +12,10 @@ describe('render', () => {
       </MemoryRouter>
     );
     
-    // main에 zzz가 있는지 확인
+    // header에 각 메뉴가 있는지 확인
     expect(container).toHaveTextContent('홈');
     expect(container).toHaveTextContent('투두 작성');
     expect(container).toHaveTextContent('투두 전체');
     expect(container).toHaveTextContent('로그인');
-
   });
 });

--- a/src/test/list.test.tsx
+++ b/src/test/list.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Contents from "../components/todoList/Contents"; // Contents 컴포넌트의 실제 경로로 수정하세요
+import { MemoryRouter } from "react-router-dom";
+
+// 모킹할 더미 데이터
+const dummyData = [
+  {
+    id: "1",
+    title: "Dummy Task 1",
+    detail: "Sample detail",
+    state: false,
+    startDate: "2023-10-30",
+    endDate: "2023-10-30",
+
+  },
+  {
+    id: "2",
+    title: "Dummy Task 2",
+    detail: "Sample detail",
+    state: false,
+    startDate: "2023-10-30",
+    endDate: "2023-10-30",
+  },
+];
+
+// _getTodo 함수를 모킹하고 더미 데이터 반환
+import * as todosApi from "../api/todos"; // 실제 모듈 경로로 수정하세요
+
+jest.mock("../api/todos", () => ({
+    _getTodo: (path: string) => {
+      return Promise.resolve(dummyData);
+    },
+  }));
+
+test("renders list of tasks", async () => {
+  // _getTodo 함수를 mockResolvedValue 또는 mockImplementation을 사용하여 더미 데이터 반환하도록 설정
+  todosApi._getTodo("running");
+
+  render(
+    <MemoryRouter>
+      <Contents path="running" />
+    </MemoryRouter>
+  );
+
+  // Wait for the component to render with dummy data
+  screen.findByText("Dummy Task 1");
+    screen.findByText("Dummy Task 2");
+
+});
+
+
+
+
+// Add more test cases as needed

--- a/src/test/main.test.tsx
+++ b/src/test/main.test.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render,waitFor,screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom'; // MemoryRouter를 가져옴
 import '@testing-library/jest-dom/extend-expect';
 import Main from '../pages/Main';
 
 describe('render', () => {
-  it('main_render', () => {
+  it('main_render', async() => {
     const { container } = render(
       <MemoryRouter> {/* MemoryRouter로 감싸기 */}
         <Main />
       </MemoryRouter>
     );
 
-    // main에 zzz가 있는지 확인
-    expect(container).toHaveTextContent('zzz');
+    //이미지가 있는지 확인
+    expect(screen.getByAltText("메인캐릭터")).toBeInTheDocument(); 
   });
 });


### PR DESCRIPTION
1) app 테스트케이스에 제목, 내용, 시작날짜 ,끝날짜를 입력하지않았을 때 테스트케이스 추가

        현재 테스트 항목 :
              빈 제목으로 할 일을 추가하면 에러 메시지를 표시.
              빈 내용으로 할 일을 추가하면 에러 메시지를 표시.
              빈 시작 날짜로 할 일을 추가하면 에러 메시지를 표시.
              빈 끝 날짜로 할 일을 추가하면 에러 메시지를 표시.
              정상적인 데이터로 할 일을 추가할 수 있는지 확인.

        부가적:
        제목 내용 시작날짜 끝날짜가 화면에 보이는지
        함수 호출에 올바른 인자가 전달되는지

2) add 페이지 입력값 변경함수를 useTodoValidation훅으로 따로빼서 유효성검사추가 추후 변경페이지에서 재사용가능